### PR TITLE
Extended PythonVirtualEnvOperator for venv caching

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -21,7 +21,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any, Callable, Iterable, Mapping, overload
+from typing import Any, Callable, Collection, Container, Iterable, Mapping, overload
 
 from kubernetes.client import models as k8s
 
@@ -107,6 +107,9 @@ class TaskDecoratorCollection:
         use_dill: bool = False,
         system_site_packages: bool = True,
         templates_dict: Mapping[str, Any] | None = None,
+        pip_install_options: list[str] | None = None,
+        skip_on_exit_code: int | Container[int] | None = None,
+        index_urls: None | Collection[str] | str = None,
         show_return_value_in_logs: bool = True,
         **kwargs,
     ) -> TaskDecorator:
@@ -124,6 +127,13 @@ class TaskDecoratorCollection:
         :param system_site_packages: Whether to include
             system_site_packages in your virtualenv.
             See virtualenv documentation for more information.
+        :param pip_install_options: a list of pip install options when installing requirements
+            See 'pip install -h' for available options
+        :param skip_on_exit_code: If python_callable exits with this exit code, leave the task
+            in ``skipped`` state (default: None). If set to ``None``, any non-zero
+            exit code will be treated as a failure.
+        :param index_urls: an optional list of index urls to load Python packages from.
+            If not provided the system pip conf will be used to source packages from.
         :param templates_dict: a dictionary where the values are templates that
             will get templated by the Airflow engine sometime between
             ``__init__`` and ``execute`` takes place and are made available

--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -110,6 +110,7 @@ class TaskDecoratorCollection:
         pip_install_options: list[str] | None = None,
         skip_on_exit_code: int | Container[int] | None = None,
         index_urls: None | Collection[str] | str = None,
+        venv_cache_path: None | str = None,
         show_return_value_in_logs: bool = True,
         **kwargs,
     ) -> TaskDecorator:
@@ -134,6 +135,9 @@ class TaskDecoratorCollection:
             exit code will be treated as a failure.
         :param index_urls: an optional list of index urls to load Python packages from.
             If not provided the system pip conf will be used to source packages from.
+        :param venv_cache_path: Optional path to the venv parent folder in which the venv will be cached,
+            creates a sub-folder venv-{hash} whereas hash will be replaced with a checksum of requirements.
+            If not provided the venv will be created and deleted in a temp folder for every execution.
         :param templates_dict: a dictionary where the values are templates that
             will get templated by the Airflow engine sometime between
             ``__init__`` and ``execute`` takes place and are made available

--- a/airflow/hooks/package_index.py
+++ b/airflow/hooks/package_index.py
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Hook for additional Package Indexes (Python)."""
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from urllib.parse import quote, urlparse
+
+from airflow.hooks.base import BaseHook
+
+
+class PackageIndexHook(BaseHook):
+    """Specify package indexes/Python package sources using Airflow connections."""
+
+    conn_name_attr = "pi_conn_id"
+    default_conn_name = "package_index_default"
+    conn_type = "package_index"
+    hook_name = "Package Index (Python)"
+
+    def __init__(self, pi_conn_id: str = default_conn_name) -> None:
+        super().__init__()
+        self.pi_conn_id = pi_conn_id
+        self.conn = None
+
+    @staticmethod
+    def get_ui_field_behaviour() -> dict[str, Any]:
+        """Returns custom field behaviour."""
+        return {
+            "hidden_fields": ["schema", "port", "extra"],
+            "relabeling": {"host": "Package Index URL"},
+            "placeholders": {
+                "host": "Example: https://my-package-mirror.net/pypi/repo-name/simple",
+                "login": "Username for package index",
+                "password": "Password for package index (will be masked)",
+            },
+        }
+
+    @staticmethod
+    def _get_basic_auth_conn_url(index_url: str, user: str | None, password: str | None) -> str:
+        """Returns a connection URL with basic auth credentials based on connection config."""
+        url = urlparse(index_url)
+        host = url.netloc.split("@")[-1]
+        if user:
+            if password:
+                host = f"{quote(user)}:{quote(password)}@{host}"
+            else:
+                host = f"{quote(user)}@{host}"
+        return url._replace(netloc=host).geturl()
+
+    def get_conn(self) -> Any:
+        """Returns connection for the hook."""
+        return self.get_connection_url()
+
+    def get_connection_url(self) -> Any:
+        """Returns a connection URL with embedded credentials."""
+        conn = self.get_connection(self.pi_conn_id)
+        index_url = conn.host
+        if not index_url:
+            raise Exception("Please provide an index URL.")
+        return self._get_basic_auth_conn_url(index_url, conn.login, conn.password)
+
+    def test_connection(self) -> tuple[bool, str]:
+        """Test connection to package index url."""
+        conn_url = self.get_connection_url()
+        proc = subprocess.run(
+            ["pip", "search", "not-existing-test-package", "--no-input", "--index", conn_url],
+            check=False,
+            capture_output=True,
+        )
+        conn = self.get_connection(self.pi_conn_id)
+        if proc.returncode not in [
+            0,  # executed successfully, found package
+            23,  # executed successfully, didn't find any packages
+            #      (but we do not expect it to find 'not-existing-test-package')
+        ]:
+            return False, f"Connection test to {conn.host} failed. Error: {str(proc.stderr)}"
+
+        return True, f"Connection to {conn.host} tested successfully!"

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import fcntl
 import importlib
 import inspect
 import logging
@@ -45,6 +46,7 @@ from airflow.exceptions import (
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.skipmixin import SkipMixin
 from airflow.models.taskinstance import _CURRENT_CONTEXT
+from airflow.utils import hashlib_wrapper
 from airflow.utils.context import Context, context_copy_partial, context_merge
 from airflow.utils.operator_helpers import KeywordParameters
 from airflow.utils.process_utils import execute_in_subprocess
@@ -509,6 +511,9 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         exit code will be treated as a failure.
     :param index_urls: an optional list of index urls to load Python packages from.
         If not provided the system pip conf will be used to source packages from.
+    :param venv_cache_path: Optional path to the venv parent folder in which the venv will be cached,
+        creates a sub-folder venv-{hash} whereas hash will be replaced with a checksum of requirements.
+        If not provided the venv will be created and deleted in a temp folder for every execution.
     """
 
     template_fields: Sequence[str] = tuple({"requirements"} | set(PythonOperator.template_fields))
@@ -531,6 +536,7 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         expect_airflow: bool = True,
         skip_on_exit_code: int | Container[int] | None = None,
         index_urls: None | Collection[str] | str = None,
+        venv_cache_path: None | str = None,
         **kwargs,
     ):
         if (
@@ -560,6 +566,7 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
             self.index_urls = list(index_urls)
         else:
             self.index_urls = None
+        self.venv_cache_path = Path(venv_cache_path) if venv_cache_path else None
         super().__init__(
             python_callable=python_callable,
             use_dill=use_dill,
@@ -594,7 +601,31 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
             index_urls=self.index_urls,
         )
 
+    def _ensure_venv_cache_exists(self, venv_cache_path: Path) -> Path:
+        """Helper to ensure a valid venv is set up and will create inplace."""
+        hash_object = hashlib_wrapper.md5(",".join(self._requirements_list()).encode())
+        requirements_hash = hash_object.hexdigest()
+        venv_path = venv_cache_path / f"venv-{requirements_hash[0:8]}"
+        self.log.info("Python Virtualenv will be cached in %s", venv_path)
+        venv_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(f"{venv_path}.lock", "w") as f:
+            # Ensure that cache is not build by parallel workers
+            fcntl.flock(f, fcntl.LOCK_EX)
+
+            if venv_path.exists():
+                self.log.info("Re-using cached Python Virtualenv in %s", venv_path)
+            else:
+                venv_path.mkdir(parents=True)
+                self._prepare_venv(venv_path)
+                self.log.info("New Python Virtualenv created in %s", venv_path)
+            return venv_path
+
     def execute_callable(self):
+        if self.venv_cache_path:
+            venv_path = self._ensure_venv_cache_exists(self.venv_cache_path)
+            python_path = venv_path / "bin" / "python"
+            return self._execute_python_callable_in_subprocess(python_path, venv_path)
+
         with TemporaryDirectory(prefix="venv") as tmp_dir:
             tmp_path = Path(tmp_dir)
             self._prepare_venv(tmp_path)

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -37,6 +37,7 @@ from packaging.utils import canonicalize_name
 
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.hooks.filesystem import FSHook
+from airflow.hooks.package_index import PackageIndexHook
 from airflow.typing_compat import Literal
 from airflow.utils import yaml
 from airflow.utils.entry_points import entry_points_with_dist
@@ -458,7 +459,7 @@ class ProvidersManager(LoggingMixin, metaclass=Singleton):
                 connection_type=None,
                 connection_testable=False,
             )
-        for cls in [FSHook]:
+        for cls in [FSHook, PackageIndexHook]:
             package_name = cls.__module__
             hook_class_name = f"{cls.__module__}.{cls.__name__}"
             hook_info = self._import_hook(

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -112,6 +112,20 @@ If additional parameters for package installation are needed pass them in ``requ
 
 All supported options are listed in the `requirements file format <https://pip.pypa.io/en/stable/reference/requirements-file-format/#supported-options>`_.
 
+Virtualenv setup options
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The virtualenv is created based on the global python pip configuration on your worker. Using additional ENVs in your environment or adjustments in the general
+pip configuration as described in `pip config <https://pip.pypa.io/en/stable/topics/configuration/>`_.
+
+If you want to use additional task specific private python repositories to setup the virtualenv, you can pass the ``index_urls`` parameter which will adjust the
+pip install configurations. Passed index urls replace the standard system configured index url settings.
+To prevent adding secrets to the private repository in your DAG code you can use the Airflow
+:doc:`../../authoring-and-scheduling/connections`. For this purpose the connection type ``Package Index (Python)`` can be used.
+
+In the special case you want to prevent remote calls for setup of a virtualenv, pass the ``index_urls`` as empty list as ``index_urls=[]`` which
+forced pip installer to use the ``--no-index`` option.
+
 
 .. _howto/operator:ExternalPythonOperator:
 

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -126,6 +126,18 @@ To prevent adding secrets to the private repository in your DAG code you can use
 In the special case you want to prevent remote calls for setup of a virtualenv, pass the ``index_urls`` as empty list as ``index_urls=[]`` which
 forced pip installer to use the ``--no-index`` option.
 
+Caching and re-use
+^^^^^^^^^^^^^^^^^^
+
+Setup of virtualenvs is made per task execution in a temporary directory. After execution the virtualenv is deleted again. Ensure that the ``$tmp`` folder
+on your workers have sufficient disk space. Usually (if not configured differently) the local pip cache will be used preventing a re-download of packages
+for each execution.
+
+But still setting up the virtualenv for every execution needs some time. For repeated execution you can set the option ``venv_cache_path`` to a file system
+folder on your worker. In this case the virtualenv will be set up once and be re-used. If venv caching is used, per unique requirements set different
+virtualenv subfolders are created in the cache path. So depending on your variations in the DAGs in your system setup sufficient disk space is needed.
+Note that no automated cleanup is made and in case of cached mode. All worker slots share the same virtualenv.
+
 
 .. _howto/operator:ExternalPythonOperator:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1617,6 +1617,7 @@ Url
 url
 urlencoded
 urlparse
+urls
 useHCatalog
 useLegacySQL
 useQueryCache
@@ -1637,6 +1638,7 @@ vCPU
 ve
 vendored
 Vendorize
+venv
 venvs
 versionable
 Vertica
@@ -1646,6 +1648,7 @@ Vevo
 videointelligence
 VideoIntelligenceServiceClient
 virtualenv
+virtualenvs
 vm
 VolumeMount
 volumeMounts

--- a/tests/hooks/test_package_index.py
+++ b/tests/hooks/test_package_index.py
@@ -1,0 +1,122 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Test for Package Index Hook."""
+from __future__ import annotations
+
+from pytest import FixtureRequest, MonkeyPatch, fixture, mark, raises
+
+from airflow.hooks.package_index import PackageIndexHook
+from airflow.models.connection import Connection
+
+
+class MockConnection(Connection):
+    """Mock for the Connection class."""
+
+    def __init__(self, host: str | None, login: str | None, password: str | None):
+        super().__init__()
+        self.host = host
+        self.login = login
+        self.password = password
+
+
+PI_MOCK_TESTDATA = {
+    "missing-url": {},
+    "anonymous-https": {
+        "host": "https://site/path",
+        "expected_result": "https://site/path",
+    },
+    "no_password-http": {
+        "host": "http://site/path",
+        "login": "any_user",
+        "expected_result": "http://any_user@site/path",
+    },
+    "with_password-http": {
+        "host": "http://site/path",
+        "login": "any_user",
+        "password": "secret@_%1234!",
+        "expected_result": "http://any_user:secret%40_%251234%21@site/path",
+    },
+    "with_password-https": {
+        "host": "https://old_user:pass@site/path",
+        "login": "any_user",
+        "password": "secret@_%1234!",
+        "expected_result": "https://any_user:secret%40_%251234%21@site/path",
+    },
+}
+
+
+@fixture(
+    params=list(PI_MOCK_TESTDATA.values()),
+    ids=list(PI_MOCK_TESTDATA.keys()),
+)
+def mock_get_connection(monkeypatch: MonkeyPatch, request: FixtureRequest) -> str | None:
+    """Pytest Fixture."""
+    testdata: dict[str, str | None] = request.param
+    host: str | None = testdata.get("host", None)
+    login: str | None = testdata.get("login", None)
+    password: str | None = testdata.get("password", None)
+    expected_result: str | None = testdata.get("expected_result", None)
+    monkeypatch.setattr(
+        "airflow.hooks.package_index.PackageIndexHook.get_connection",
+        lambda *_: MockConnection(host, login, password),
+    )
+    return expected_result
+
+
+def test_get_connection_url(mock_get_connection: str | None):
+    """Test if connection url is assembled correctly from credentials and index_url."""
+    expected_result = mock_get_connection
+    hook_instance = PackageIndexHook()
+    if expected_result:
+        connection_url = hook_instance.get_connection_url()
+        assert connection_url == expected_result
+    else:
+        with raises(Exception):
+            hook_instance.get_connection_url()
+
+
+@mark.parametrize("success", [0, 1])
+def test_test_connection(monkeypatch: MonkeyPatch, mock_get_connection: str | None, success: int):
+    """Test if connection test responds correctly to return code."""
+
+    def mock_run(*_, **__):
+        class MockProc:
+            """Mock class."""
+
+            returncode = success
+            stderr = "some error text"
+
+        return MockProc()
+
+    monkeypatch.setattr("airflow.hooks.package_index.subprocess.run", mock_run)
+
+    hook_instance = PackageIndexHook()
+    if mock_get_connection:
+        result = hook_instance.test_connection()
+        assert result[0] == (success == 0)
+    else:
+        with raises(Exception):
+            hook_instance.test_connection()
+
+
+def test_get_ui_field_behaviour():
+    """Tests UI field result structure"""
+    ui_field_behavior = PackageIndexHook.get_ui_field_behaviour()
+    assert "hidden_fields" in ui_field_behavior
+    assert "relabeling" in ui_field_behavior
+    assert "placeholders" in ui_field_behavior

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -929,6 +929,7 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
             pip_install_options=["--no-deps"],
         )
         mocked_prepare_virtualenv.assert_called_with(
+            index_urls=None,
             venv_directory=mock.ANY,
             python_bin=mock.ANY,
             system_site_packages=False,
@@ -968,6 +969,18 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
             return a
 
         self.run_as_task(f, system_site_packages=False, use_dill=False, op_args=[4])
+
+    def test_with_index_urls(self):
+        def f(a):
+            import sys
+            from pathlib import Path
+
+            pip_conf = (Path(sys.executable).parent.parent / "pip.conf").read_text()
+            assert "abc.def.de" in pip_conf
+            assert "xyz.abc.de" in pip_conf
+            return a
+
+        self.run_as_task(f, index_urls=["https://abc.def.de", "http://xyz.abc.de"], op_args=[4])
 
     # This tests might take longer than default 60 seconds as it is serializing a lot of
     # context using dill (which is slow apparently).

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -26,6 +26,7 @@ import warnings
 from collections import namedtuple
 from datetime import date, datetime, timedelta
 from subprocess import CalledProcessError
+from tempfile import TemporaryDirectory
 from typing import Generator
 from unittest import mock
 from unittest.mock import MagicMock
@@ -981,6 +982,16 @@ class TestPythonVirtualenvOperator(BaseTestPythonVirtualenvOperator):
             return a
 
         self.run_as_task(f, index_urls=["https://abc.def.de", "http://xyz.abc.de"], op_args=[4])
+
+    def test_caching(self):
+        def f(a):
+            import sys
+
+            assert "pytest_venv_1234" in sys.executable
+            return a
+
+        with TemporaryDirectory(prefix="pytest_venv_1234") as tmp_dir:
+            self.run_as_task(f, venv_cache_path=tmp_dir, op_args=[4])
 
     # This tests might take longer than default 60 seconds as it is serializing a lot of
     # context using dill (which is slow apparently).

--- a/tests/utils/test_python_virtualenv.py
+++ b/tests/utils/test_python_virtualenv.py
@@ -18,13 +18,48 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from airflow.utils.decorators import remove_task_decorator
-from airflow.utils.python_virtualenv import prepare_virtualenv
+from airflow.utils.python_virtualenv import _generate_pip_conf, prepare_virtualenv
 
 
 class TestPrepareVirtualenv:
+    @pytest.mark.parametrize(
+        ("index_urls", "expected_pip_conf_content", "unexpected_pip_conf_content"),
+        [
+            [[], ["[global]", "no-index ="], ["index-url", "extra", "http", "pypi"]],
+            [["http://mysite"], ["[global]", "index-url", "http://mysite"], ["no-index", "extra", "pypi"]],
+            [
+                ["http://mysite", "https://othersite"],
+                ["[global]", "index-url", "http://mysite", "extra", "https://othersite"],
+                ["no-index", "pypi"],
+            ],
+            [
+                ["http://mysite", "https://othersite", "http://site"],
+                ["[global]", "index-url", "http://mysite", "extra", "https://othersite http://site"],
+                ["no-index", "pypi"],
+            ],
+        ],
+    )
+    def test_generate_pip_conf(
+        self,
+        index_urls: list[str],
+        expected_pip_conf_content: list[str],
+        unexpected_pip_conf_content: list[str],
+        tmp_path: Path,
+    ):
+        tmp_file = tmp_path / "pip.conf"
+        _generate_pip_conf(tmp_file, index_urls)
+        generated_conf = tmp_file.read_text()
+        for term in expected_pip_conf_content:
+            assert term in generated_conf
+        for term in unexpected_pip_conf_content:
+            assert term not in generated_conf
+
     @mock.patch("airflow.utils.python_virtualenv.execute_in_subprocess")
     def test_should_create_virtualenv(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(


### PR DESCRIPTION
This PR is a follow-up and split of the PR https://github.com/apache/airflow/pull/33017 to add virtualenv caching to PythonVirtualEnvOperator.

As it builds on top of the other branch it needs to be merged behind, else we run into merge conflicts.

Therefore before merging, the rarget repo need to be switched to apache/airflow:main.

FYI @AutomationDev85 @clellmann @wolfdn